### PR TITLE
Separate call-level and session-level contexts

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -48,7 +48,7 @@ func DialContext(ctx context.Context, network, address string) (*Conn, error) {
 }
 
 // DialContext connects the ZK client to the specified Zookeeper server.
-// The provided context is used to determine the lifetime of the session.
+// The provided context is used to determine the dial lifetime.
 func (client *Client) DialContext(ctx context.Context, network, address string) (*Conn, error) {
 	c := &Conn{
 		passwd: emptyPassword,


### PR DESCRIPTION
Addressing [discussion](https://github.com/facebookincubator/zk/pull/16/files/80cd74d4f1ef42fb5a72b1fdd923428eecf9bd7e?file-filters%5B%5D=.go&hide-deleted-files=true#r674210150
) from previous PR