### PR TITLE
Close goroutine when connection is closed

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -184,6 +184,9 @@ func (c *Conn) handleReads(ctx context.Context) {
 		default:
 			dec := jute.NewBinaryDecoder(c.conn)
 			_, err := dec.ReadInt() // read response length
+			if errors.Is(err, net.ErrClosed) {
+				return // don't make further attempts to read from closed connection, close goroutine
+			}
 			if err != nil {
 				log.Printf("could not decode response length: %v", err)
 				break


### PR DESCRIPTION
This is so that we don't log errors when connection is closed. While using the library, it was noticed that the read goroutine would consistently read from a connection when it was closed, and before it got the `Done()` signal from its session context. This way we can gracefully close the goroutine without unnecessarily logging `net.ErrClosed`.