### PR TITLE
Example CLI

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -9,39 +9,68 @@ import (
 	"github.com/facebookincubator/zk"
 )
 
+const usage = `
+usage: go run example/main.go [-server] [command] [path]
+
+This CLI is used to get data from a given Zookeeper server node.
+
+The first argument represents the command that the user wants to execute. Available commands:
+- 'get' - gets data from a Zookeeper node
+- 'list' - lists all children of a Zookeeper node
+
+The second argument is used to specify the Zookeeper node path.
+
+Users can specify server address using the --server flag, which is by default set to localhost:2181.
+
+Example usage:
+go run example/main.go get /
+go run example/main.go --server=192.168.2.3:1234 list /zookeeper
+`
+
 func main() {
-	cmd := flag.String("cmd", "get", "Command to be executed. Can be \"get\" or \"list\".")
-	path := flag.String("path", "/", "Znode path from which to get data.")
-	address := flag.String("server", "127.0.0.1:2181", "Zookeeper server address.")
+	flag.Usage = func() {
+		if _, err := fmt.Fprint(flag.CommandLine.Output(), usage); err != nil {
+			return
+		}
+	}
+
+	server := flag.String("server", "127.0.0.1:2181", "Zookeeper server address.")
 	flag.Parse()
+
+	if len(flag.Args()) != 2 {
+		flag.Usage()
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	client := zk.Client{}
-	conn, err := client.DialContext(ctx, "tcp", *address)
+	conn, err := client.DialContext(ctx, "tcp", *server)
 	if err != nil {
 		fmt.Println("error dialing server:", err)
 		return
 	}
 
-	switch *cmd {
+	cmd := flag.Args()[0]
+	path := flag.Args()[1]
+	switch cmd {
 	case "get":
-		data, err := conn.GetData(*path)
+		data, err := conn.GetData(path)
 		if err != nil {
 			fmt.Println("getData error:", err)
 			return
 		}
-		fmt.Printf("Data for node %s: %v\n", *path, string(data))
+		fmt.Printf("Data for node %s: %v\n", path, string(data))
 	case "list":
-		children, err := conn.GetChildren(*path)
+		children, err := conn.GetChildren(path)
 		if err != nil {
 			fmt.Println("getChildren error:", err)
 			return
 		}
 
-		fmt.Printf("Children of node %s: %v\n", *path, children)
+		fmt.Printf("Children of node %s: %v\n", path, children)
 	default:
-		fmt.Printf("Cannot recognize command \"%s\", exiting.\n", *cmd)
+		fmt.Printf("Cannot recognize command \"%s\", exiting.\n", cmd)
 	}
 }


### PR DESCRIPTION
Refactor `example/main.go` to make it more akin to a CLI. 

Example usage:

```
ardi@ardi-mbp zk % go run example/main.go get /
Data for node /: 
ardi@ardi-mbp zk % go run example/main.go list /zookeeper 
Children of node /zookeeper: [config quota]
```
