### PR TITLE
Test server quickfix

### DIFF
--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -68,6 +68,8 @@ func (s *TestServer) handler() {
 }
 
 func handleConn(conn net.Conn) error {
+	defer conn.Close()
+
 	if err := jute.NewBinaryDecoder(conn).ReadRecord(&proto.ConnectRequest{}); err != nil {
 		return fmt.Errorf("error reading ConnectRequest: %w", err)
 	}


### PR DESCRIPTION
Read request body after reading the header and before sending a response.
Return error if the request cannot be inferred from the header received.
