### PR TITLE
Fixes in conn code

### DIFF
--- a/client.go
+++ b/client.go
@@ -67,7 +67,6 @@ func (client *Client) doRetry(ctx context.Context, fun func() error) error {
 
 		err = fun()
 		if err != nil {
-			client.conn.Close()
 			continue // retry
 		}
 


### PR DESCRIPTION
Changes made: 

* Refactor reply handling code in the read goroutine
* Exit the read goroutine when a connection read error occurs
* Exit the keepAlive() goroutine when a connection read error occurs
