### PR TITLE
Add error code handling

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -220,7 +220,7 @@ func (c *Conn) handleReads() {
 
 		pending := value.(*pendingRequest)
 		if replyHeader.Err != 0 {
-			pending.error = &io.Error{Code: io.Code(replyHeader.Err)}
+			pending.error = &Error{Code: Code(replyHeader.Err)}
 		} else if err = dec.ReadRecord(pending.reply); err != nil {
 			log.Printf("could not decode response struct: %v", err)
 			return

--- a/conn_test.go
+++ b/conn_test.go
@@ -149,8 +149,8 @@ func TestErrorCodeHandling(t *testing.T) {
 	_, err = conn.GetChildren("/nonexisting")
 
 	// verify that the ZK server error has been processed properly
-	var ioError *zkio.Error
-	if !errors.As(err, &ioError) {
+	var zkError *Error
+	if !errors.As(err, &zkError) {
 		t.Fatalf("unexpected error calling GetChildren: %v", err)
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-package io
+package zk
 
 // Error is a wrapper for all error codes that can be returned by a Zookeeper server.
 type Error struct {


### PR DESCRIPTION
Every reply from the ZK server is prepended with a `ReplyHeader`, which has a field with an error code.
This PR introduces handling of these error codes in an uniform way.

Changes made: 
`conn.go`: 
- parse and forward errors in the `handleReads` goroutine if the header contains an error code
- return an error in the `rpc` method if the replyHeader contains an error code

`errors.go`:
- add `Error` type which is used to categorize errors received from the server in the form of error codes
- add known error codes and their descriptions

