### PR TITLE
Don't log EOF connection errors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	io2 "io"
+	"io"
 	"log"
 	"math"
 	"net"
@@ -195,7 +195,7 @@ func (c *Conn) handleReads() {
 			return
 		}
 		_, err := dec.ReadInt() // read response length
-		if errors.Is(err, net.ErrClosed) || errors.Is(err, io2.EOF) {
+		if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
 			return // don't make further attempts to read from closed connection, close goroutine
 		}
 		if err != nil {


### PR DESCRIPTION
As discussed internally - treat [io.EOF](https://cs.opensource.google/go/go/+/go1.17:src/io/io.go;l=44) the same way as [net.ErrClosed](https://cs.opensource.google/go/go/+/refs/tags/go1.17:src/net/net.go;l=648) - don't log, simply close goroutine