### PR TITLE
Fix GetXid race condition

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -14,9 +14,9 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/facebookincubator/zk/internal/proto"
@@ -260,10 +260,5 @@ func (c *Conn) clearPendingRequests() {
 }
 
 func (c *Conn) getXid() int32 {
-	if c.xid == math.MaxInt32 {
-		c.xid = 1
-	}
-	c.xid++
-
-	return c.xid
+	return atomic.AddInt32(&c.xid, 1)
 }

--- a/conn.go
+++ b/conn.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -26,6 +25,7 @@ import (
 )
 
 const defaultTimeout = 2 * time.Second
+const overflowBitMask = 1<<31 - 1
 
 // Conn represents a client connection to a Zookeeper server and parameters needed to handle its lifetime.
 type Conn struct {
@@ -260,5 +260,5 @@ func (c *Conn) clearPendingRequests() {
 }
 
 func (c *Conn) nextXid() int32 {
-	return atomic.AddInt32(&c.xid, 1) & math.MaxInt32
+	return atomic.AddInt32(&c.xid, 1) & overflowBitMask
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"net"
 	"reflect"
 	"testing"
@@ -159,5 +160,21 @@ func TestErrorCodeHandling(t *testing.T) {
 	var zkError *Error
 	if !errors.As(err, &zkError) {
 		t.Fatalf("unexpected error calling GetChildren: %v", err)
+	}
+}
+
+func TestNextXid(t *testing.T) {
+	conn := &Conn{}
+
+	if conn.nextXid() != 1 {
+		t.Fatalf("expected nextXid to increment from 0 to 1")
+	}
+}
+
+func TestNextXidOverflow(t *testing.T) {
+	conn := &Conn{xid: math.MaxInt32}
+
+	if conn.nextXid() != 0 {
+		t.Fatalf("expected nextXid not to overflow")
 	}
 }


### PR DESCRIPTION
Found a data race in the getXid() method with concurrent access `Conn`'s `xid` field.
Using the `sync/atomic` package addreses this race condition.